### PR TITLE
Install dprint to keep consistent format

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -39,3 +39,14 @@ jobs:
     - name: Run Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
 
+  mdtomlfmt:
+    name: Generic format (md,toml)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run dprint
+      run: |
+        curl -fsSL https://dprint.dev/install.sh | sh
+        /home/runner/.dprint/bin/dprint check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,62 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field).
 
 ## [Unreleased]
-N/A
 
 ## [0.3.1] - 2021-09-27
+
 ### Changed
+
 - CI migrated to GitHub Actions with more tests and build
 - `hex` dependency bumped from `0.3` to `0.4` ([#2](https://github.com/monero-rs/base58-monero/pull/2))
 
 ### Added
+
 - Minimum Stable Rust Version of `1.45.2`
 - Changelog tracking past and futur release
 - Benchmarks and results in README ([#6](https://github.com/monero-rs/base58-monero/pull/6))
 - Code coverage ([#7](https://github.com/monero-rs/base58-monero/pull/7))
 
 ## [0.3.0] - 2021-04-09
+
 ### Changed
+
 - Update to `tokio` version `"1"` ([#1](https://github.com/monero-rs/base58-monero/pull/1))
 - Improve async doc code example tests runtime with `tokio_test`
 - Add more documentation about `check` and `stream` features
 
 ## [0.2.1] - 2021-03-19
+
 ### Changed
+
 - Use `thiserror` to handle display, from and error implementation on `base58::Error`
 
 ## [0.2.0] - 2020-01-09
+
 ### Added
+
 - New `stream` feature for asynchronous streams
 - More test vectors
 
 ### Changed
+
 - Improved documentation with examples
 
 ## [0.1.1] - 2019-03-09
+
 ### Added
+
 - File header
 - Trait `std::error::Error` on `Error`
 
 ## [0.1.0] - 2019-03-06
+
 ### Added
+
 - Initial release of the library
 
 [Unreleased]: https://github.com/monero-rs/base58-monero/compare/v0.3.1...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "base58-monero"
-description = "Library with support for encoding/decoding Monero base58 strings."
-keywords = ["monero", "base58", "base58-check"]
 version = "0.3.1"
 authors = ["Monero Rust Contributors", "h4sh3d <h4sh3d@protonmail.com>"]
-license = "MIT"
 documentation = "https://docs.rs/base58-monero"
 homepage = "https://github.com/monero-rs/base58-monero"
-repository = "https://github.com/monero-rs/base58-monero"
-readme = "README.md"
 include = [
-    "src/*",
-    "README.md",
-    "LICENSE",
+  "src/*",
+  "README.md",
+  "LICENSE",
 ]
+keywords = ["monero", "base58", "base58-check"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/monero-rs/base58-monero"
+description = "Library with support for encoding/decoding Monero base58 strings."
 
 edition = "2018"
 
@@ -23,11 +23,11 @@ stream = ["tokio", "async-stream", "futures-util"]
 default = ["check", "stream"]
 
 [dependencies]
-tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
 async-stream = { version = "0.3", optional = true }
-tokio = { version = "1", features = ["io-util"], optional = true }
 futures-util = { version = "0.3.1", optional = true }
 thiserror = "1.0.24"
+tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
+tokio = { version = "1", features = ["io-util"], optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![MSRV](https://img.shields.io/badge/MSRV-1.45.2-blue)
 
-Rust Monero Base58
-===
+# Rust Monero Base58
 
 Library with support for encoding/decoding Monero base58 strings, with and without checksum
 verification.
@@ -52,27 +51,23 @@ amount of data or in asyncronous environment. `stream` can be used with `check` 
 Results obtained on an Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz with a standard Monero address as data source.
 Performances are shown in nanosecond per iteration of compute, the smaller the better:
 
-| Operation | Regular            | `_check`             |
-| --------- | ------------------ | -------------------- |
-| `encode`  | 652 ns (+/- 107)   | 1,272 ns (+/- 760)
-| `decode`  | 612 ns (+/- 82)    | 1,187 ns (+/- 541)
+| Operation | Regular          | `_check`           |
+| --------- | ---------------- | ------------------ |
+| `encode`  | 652 ns (+/- 107) | 1,272 ns (+/- 760) |
+| `decode`  | 612 ns (+/- 82)  | 1,187 ns (+/- 541) |
 
 Check versions compute or verify the checksum while encoding or decoding the data.
 
 Benchmarks can be found under `/benches` and run with `cargo +nightly bench`.
 
-Release Notes
-===
+## Release Notes
 
 See [CHANGELOG.md](CHANGELOG.md).
 
-About
-===
+## About
 
-This started as a research project sponsored by TrueLevel SA. It is now maintained by community
-members.
+This started as a research project sponsored by TrueLevel SA. It is now maintained by community members.
 
-Licensing
-===
+## Licensing
 
 The code in this project is licensed under the [MIT License](LICENSE)

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,13 @@
+{
+  "incremental": true,
+  "markdown": {
+  },
+  "toml": {
+  },
+  "includes": ["**/*.{md,toml}"],
+  "excludes": ["target"],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.11.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.3.wasm"
+  ]
+}


### PR DESCRIPTION
Ran dprint and add CI check for markdown and toml files.