### PR TITLE
feat: add codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 1
+  round: down
+  range: "50...95"


### PR DESCRIPTION
Round at 1 digit instead of 2, should helps erroring with 0.0x% decrease in coverage.