### PR TITLE
chore: update 2022 headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 Monero Rust Contributors
+Copyright (c) 2019-2022 Monero Rust Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -1,5 +1,5 @@
 // Rust Monero Base58 Library
-// Written in 2019-2021 by
+// Written in 2019-2022 by
 //   Monero Rust Contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Rust Monero Base58 Library
-// Written in 2019-2021 by
+// Written in 2019-2022 by
 //   Monero Rust Contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Simple header bump for 2022