### PR TITLE
chore: prepare release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default only `check` feature is enabled. If you don't want to include all def
 
 ```toml
 [dependencies.base58-monero]
-version = "0.3"
+version = "1"
 default-features = false
 ```
 
@@ -50,7 +50,7 @@ amount of data or in asyncronous environment. `stream` can be used with `check` 
 
 ```toml
 [dependencies.base58-monero]
-version = "0.3"
+version = "1"
 features = ["stream"]
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,13 @@
 //! Only `check` feature is enabled by default, to remove it use:
 //!
 //! ```text
-//! base58-monero = { version = "0.3", default-features = false }
+//! base58-monero = { version = "1", default-features = false }
 //! ```
 //!
 //! or to enable `stream` one use:
 //!
 //! ```text
-//! base58-monero = { version = "0.3", features = ["stream"] }
+//! base58-monero = { version = "1", features = ["stream"] }
 //! ```
 //!
 //! ## Examples


### PR DESCRIPTION
Update documentation to point to version `1.0.0`