### PR TITLE
No_std Environment Support for All Features Except Streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2023-02-20
 
 ### Added
+
 - Implement no_std environment support for all features except streaming
 
 ### Removed
+
 - Set default-features to false
 - Removed unnecessary thiserror package
 
 ### Changed
+
 - Refactored custom Error enum to not depend on thiserror and to only use std for the stream feature
 - Use alloc and core in place of std where possible
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2023-02-20
+
+### Added
+- Implement no_std environment support for all features except streaming
+
+### Removed
+- Set default-features to false
+- Removed unnecessary thiserror package
+
+### Changed
+- Refactored custom Error enum to not depend on thiserror and to only use std for the stream feature
+- Use alloc and core in place of std where possible
+
 ## [1.0.0] - 2022-06-27
 
 ### Removed
@@ -82,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of the library
 
 [Unreleased]: https://github.com/monero-rs/base58-monero/compare/v1.0.0...HEAD
+[1.1.0]: https://github.com/monero-rs/base58-monero/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/monero-rs/base58-monero/compare/v0.3.2...v1.0.0
 [0.3.2]: https://github.com/monero-rs/base58-monero/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/monero-rs/base58-monero/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2023-02-20
-
 ### Added
 
 - Implement no_std environment support for all features except streaming
@@ -98,7 +96,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of the library
 
 [Unreleased]: https://github.com/monero-rs/base58-monero/compare/v1.0.0...HEAD
-[1.1.0]: https://github.com/monero-rs/base58-monero/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/monero-rs/base58-monero/compare/v0.3.2...v1.0.0
 [0.3.2]: https://github.com/monero-rs/base58-monero/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/monero-rs/base58-monero/compare/v0.3.0...v0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base58-monero"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Monero Rust Contributors", "h4sh3d <h4sh3d@protonmail.com>"]
 documentation = "https://docs.rs/base58-monero"
 homepage = "https://github.com/monero-rs/base58-monero"
@@ -26,11 +26,10 @@ stream = ["tokio", "async-stream", "futures-util"]
 default = ["check"]
 
 [dependencies]
-async-stream = { version = "0.3", optional = true }
-futures-util = { version = "0.3.1", optional = true }
-thiserror = "1.0.24"
-tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
-tokio = { version = "1", features = ["io-util"], optional = true }
+async-stream = { version = "0.3", optional = true, default-features = false }
+futures-util = { version = "0.3.1", optional = true, default-features = false }
+tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true, default-features = false }
+tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 
 [dev-dependencies]
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ msrv = "1.49.0"
 [features]
 check = ["tiny-keccak"]
 stream = ["tokio", "async-stream", "futures-util"]
-default = []
+default = ["check"]
 
 [dependencies]
 async-stream = { version = "0.3", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ msrv = "1.49.0"
 [features]
 check = ["tiny-keccak"]
 stream = ["tokio", "async-stream", "futures-util"]
-default = ["check"]
+default = []
 
 [dependencies]
 async-stream = { version = "0.3", optional = true, default-features = false }

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -78,14 +78,17 @@ use futures_util::stream::Stream;
 use futures_util::{pin_mut, stream::StreamExt};
 #[cfg(feature = "check")]
 use tiny_keccak::{Hasher, Keccak};
+
 #[cfg(feature = "stream")]
 use tokio::io::AsyncReadExt;
-
-use thiserror::Error;
-
 #[cfg(feature = "stream")]
-use std::io;
-use std::num::Wrapping;
+use tokio::io;
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::num::Wrapping;
+
 
 /// Base58 alphabet, does not contains visualy similar characters
 pub const BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -99,21 +102,17 @@ pub const FULL_ENCODED_BLOCK_SIZE: usize = ENCODED_BLOCK_SIZES[FULL_BLOCK_SIZE];
 pub const CHECKSUM_SIZE: usize = 4;
 
 /// Possible errors when encoding/decoding base58 and base58-check strings
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// Invalid block size, must be `1..=8`
-    #[error("Invalid block size error")]
     InvalidBlockSize,
     /// Symbol not in base58 alphabet
-    #[error("Invalid symbol error")]
     InvalidSymbol,
     /// Invalid 4-bytes checksum
     #[cfg(feature = "check")]
     #[cfg_attr(docsrs, doc(cfg(feature = "check")))]
-    #[error("Invalid checksum error")]
     InvalidChecksum,
     /// Decoding overflow
-    #[error("Overflow error")]
     Overflow,
     /// IO error on stream
     ///
@@ -121,8 +120,31 @@ pub enum Error {
     /// test the wrapped errors.
     #[cfg(feature = "stream")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
+    Io(io::Error),
+}
+
+// Implementation of the From trait to allow conversion from an io::Error to Error variant Io.
+#[cfg(feature = "stream")]
+impl From<io::Error> for Error {
+    fn from(v: io::Error) -> Self {
+        Self::Io(v)
+    }
+}
+
+// Message to display when Error variants thrown.
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        let message = match self {
+            Error::InvalidBlockSize => "Invalid block size error",
+            Error::InvalidSymbol => "Invalid symbol error",
+            Error::InvalidChecksum => "Invalid checksum error",
+            Error::Overflow => "Overflow error",
+            #[cfg(feature = "stream")]
+            // Ignore what Io error is wrapped
+            Error::Io(_) => "IO error: {0}",
+        };
+        write!(f, "{}", message)
+    }
 }
 
 impl PartialEq for Error {
@@ -141,7 +163,7 @@ impl PartialEq for Error {
 }
 
 /// Utility type for handling results with base58 error type
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 fn u8be_to_u64(data: &[u8]) -> u64 {
     let mut res = 0u64;
@@ -197,7 +219,7 @@ fn decode_block(data: &[u8]) -> Result<DecodedBlock> {
         })?;
 
     let max: u128 = match res_size {
-        8 => std::u64::MAX as u128 + 1,
+        8 => core::u64::MAX as u128 + 1,
         0..=7 => 1 << (res_size * 8),
         _ => unreachable!(),
     };
@@ -466,8 +488,14 @@ where
     }
 }
 
+
+
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
     use super::{
         decode, decode_block, encode, encode_block, u8be_to_u64, Error, ENCODED_BLOCK_SIZES,
         FULL_BLOCK_SIZE, FULL_ENCODED_BLOCK_SIZE,

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -80,15 +80,14 @@ use futures_util::{pin_mut, stream::StreamExt};
 use tiny_keccak::{Hasher, Keccak};
 
 #[cfg(feature = "stream")]
-use tokio::io::AsyncReadExt;
-#[cfg(feature = "stream")]
 use tokio::io;
+#[cfg(feature = "stream")]
+use tokio::io::AsyncReadExt;
 
 extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::num::Wrapping;
-
 
 /// Base58 alphabet, does not contains visualy similar characters
 pub const BASE58_CHARS: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -137,6 +136,7 @@ impl core::fmt::Display for Error {
         let message = match self {
             Error::InvalidBlockSize => "Invalid block size error",
             Error::InvalidSymbol => "Invalid symbol error",
+            #[cfg(feature = "check")]
             Error::InvalidChecksum => "Invalid checksum error",
             Error::Overflow => "Overflow error",
             #[cfg(feature = "stream")]
@@ -487,8 +487,6 @@ where
         }
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@
 // Coding conventions
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+// Use a no_std environment except for all features except the streaming feature
+#![cfg_attr(not(feature = "stream"), no_std)]
 
 pub mod base58;
 


### PR DESCRIPTION
This pull request implements `no_std` environment support for all features except streaming. The `default-features` have been set to false, and the unnecessary `thiserror` package has been removed since it's not `no_std` compatible. Additionally, `alloc` and `core` have been used in place of `std` where possible, and the custom Error enum has been refactored to not depend on `thiserror` and to only use `std` for the stream feature. All tests have been passed, and the speed remains the same.

Additionally tested in a real world embedded project, and found it to compile without issue in the no_std environment for an ARM target (RPi Pico).