### PR TITLE
Fix: new std feature to handle std error trait

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       run: cargo build --verbose
 
     - name: Build wasm with check feature
-      run: cargo build --verbose --no-default-features --features check
+      run: cargo build --verbose --target wasm32-unknown-unknown --no-default-features --features check
 
   test:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Backward compatibility is guarantee when default features are not disabled in downstream crates
 
-## [1.1.0] - 2023-03-11
+## (YANKED) [1.1.0] - 2023-03-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New default `std` feature enabling `thiserror` crate to handle `std::error::Error` implementation on `Error` enum
+
 ### Changed
 
 - Rust edition `2021` and MSRV `1.63.0`
+
+### Fixed
+
+- Backward compatibility is guarantee when default features are not disabled in downstream crates
 
 ## [1.1.0] - 2023-03-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,16 @@ rust-version = "1.63.0"
 [package.metadata]
 
 [features]
+std = ["thiserror"]
 check = ["tiny-keccak"]
-stream = ["tokio", "async-stream", "futures-util"]
-default = ["check"]
+stream = ["std", "tokio", "async-stream", "futures-util"]
+default = ["std", "check"]
 
 [dependencies]
 async-stream = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3.1", optional = true, default-features = false }
 tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true, default-features = false }
+thiserror = { version = "1", optional = true }
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ default = ["std", "check"]
 [dependencies]
 async-stream = { version = "0.3", optional = true, default-features = false }
 futures-util = { version = "0.3.1", optional = true, default-features = false }
-tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true, default-features = false }
 thiserror = { version = "1", optional = true }
+tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true, default-features = false }
 tokio = { version = "1", features = ["io-util"], optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -27,13 +27,19 @@ The alphabet is composed of 58 characters visually not similar to avoid confusio
 
 ## Features
 
-By default only `check` feature is enabled. If you don't want to include all default features in your project:
+By default only `check` and `std` features are enabled. If you don't want to include all default
+features in your project:
 
 ```toml
 [dependencies.base58-monero]
 version = "1"
 default-features = false
 ```
+
+### `std`
+
+Disable this feature if you want to build in a `no_std` environment. This feature is required when `steam`
+is enabled.
 
 ### `check`
 
@@ -53,6 +59,8 @@ amount of data or in asyncronous environment. `stream` can be used with `check` 
 version = "1"
 features = ["stream"]
 ```
+
+This feature enables the `std` feature.
 
 ## Tests
 

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -84,6 +84,9 @@ use tokio::io;
 #[cfg(feature = "stream")]
 use tokio::io::AsyncReadExt;
 
+#[cfg(feature = "std")]
+use thiserror::Error;
+
 extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -102,6 +105,7 @@ pub const CHECKSUM_SIZE: usize = 4;
 
 /// Possible errors when encoding/decoding base58 and base58-check strings
 #[derive(Debug)]
+#[cfg_attr(feature = "std", derive(Error))]
 pub enum Error {
     /// Invalid block size, must be `1..=8`
     InvalidBlockSize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,11 @@
 //!
 //! ## Features
 //!
+//!  * `std`: enable std error implementation on the Error enum.
 //!  * `check`: enable encoding/decoding base58 strings with a 4 bytes tail checksum.
 //!  * `stream`: enable encoding/decoding base58 asyncronous streams of data.
 //!
-//! Only `check` feature is enabled by default, to remove it use:
+//! Only `check` and `std` features are enabled by default, to remove it use:
 //!
 //! ```text
 //! base58-monero = { version = "1", default-features = false }
@@ -81,8 +82,8 @@
 // Coding conventions
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-// Use a no_std environment except for all features except the streaming feature
-#![cfg_attr(not(feature = "stream"), no_std)]
+// Use a no_std environment when std feature is not enabled
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod base58;
 


### PR DESCRIPTION
Follow up to #39

`no_std` should be opt out. Before releasing `1.1.0` I didn't realize we would break compatibility with all dependent crates because `std::error::Error` implemented through `thiserror` was removed. `core::error::Error` is nightly for now so we can't make it work without this new `std` feature. For now I prefer using `thiserror` to handle derivation for us, it's common and 1 liner instead of manually keeping the implementation of `Error::source`.

Today I'm wondering if `1.1.1` is ok, but breaking dependents with: ` { version = "1", default-features = false }` or if `2.0.0` is necessary. For the later I'd then remove `check` from default as this was a bad idea from the beginning.

@mangoplane would you check that we are equivalent in a `no_std` environment as in #39 