### PR TITLE
chore: disable check by default, prepare release 2.0.0

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -37,7 +37,7 @@ jobs:
         components: clippy
 
     - name: Run Clippy
-      run: cargo clippy --workspace --all-targets -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   mdtomlfmt:
     name: Generic format (md,toml)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,17 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2.7.0
 
-    - name: Build with no default features
-      run: cargo build --verbose --no-default-features
+    - name: Base build
+      run: cargo build --verbose
 
     - name: Build with feature 'check'
-      run: cargo build --verbose --no-default-features --features check
+      run: cargo build --verbose --features check
 
     - name: Build with feature 'stream'
-      run: cargo build --verbose --no-default-features --features stream
+      run: cargo build --verbose --features stream
 
     - name: Build full features
-      run: cargo build --verbose
+      run: cargo build --verbose --all-features
 
     - name: Build wasm with check feature
       run: cargo build --verbose --target wasm32-unknown-unknown --no-default-features --features check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rust edition `2021` and MSRV `1.63.0`
-
-### Fixed
-
-- Backward compatibility is guarantee when default features are not disabled in downstream crates
+- `check` feature is disabled by default
 
 ## (YANKED) [1.1.0] - 2023-03-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.63.0"
 std = ["thiserror"]
 check = ["tiny-keccak"]
 stream = ["std", "tokio", "async-stream", "futures-util"]
-default = ["std", "check"]
+default = ["std"]
 
 [dependencies]
 async-stream = { version = "0.3", optional = true, default-features = false }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Monero Rust Contributors
+Copyright (c) 2019-2023 Monero Rust Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ Performances are shown in nanosecond per iteration of compute, the smaller the b
 
 Check versions compute or verify the checksum while encoding or decoding the data.
 
-Benchmarks can be found under `/benches` and run with `cargo +nightly bench`.
+Benchmarks can be found under `/benches` and run with
+
+```
+cargo +nightly bench --all-features
+```
 
 ## Releases and Changelog
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The alphabet is composed of 58 characters visually not similar to avoid confusio
 
 ## Features
 
-By default only `check` and `std` features are enabled. If you don't want to include all default
+By default only the `std` feature is enabled. If you want to opt-out remove default features
 features in your project:
 
 ```toml
 [dependencies.base58-monero]
-version = "1"
+version = "2"
 default-features = false
 ```
 
@@ -43,7 +43,7 @@ is enabled.
 
 ### `check`
 
-Enables `encode_check` and `decode_check` functions. By default `check` feature is enable.
+Enables `encode_check` and `decode_check` functions. By default `check` feature is disabled.
 
 ### `stream`
 
@@ -56,7 +56,7 @@ amount of data or in asyncronous environment. `stream` can be used with `check` 
 
 ```toml
 [dependencies.base58-monero]
-version = "1"
+version = "2"
 features = ["stream"]
 ```
 

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -486,7 +486,7 @@ where
             check[i] = buf[(clen - CHECKSUM_SIZE + i) % len];
         }
 
-        if check != &checksum[..CHECKSUM_SIZE] {
+        if check != checksum[..CHECKSUM_SIZE] {
             Err(Error::InvalidChecksum)?;
         }
     }

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -1,5 +1,5 @@
 // Rust Monero Base58 Library
-// Written in 2019-2022 by
+// Written in 2019-2023 by
 //   Monero Rust Contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,16 +33,16 @@
 //!  * `check`: enable encoding/decoding base58 strings with a 4 bytes tail checksum.
 //!  * `stream`: enable encoding/decoding base58 asyncronous streams of data.
 //!
-//! Only `check` and `std` features are enabled by default, to remove it use:
+//! Only the `std` feature is enabled by default, to use this crate in `no_std` environment use:
 //!
 //! ```text
-//! base58-monero = { version = "1", default-features = false }
+//! base58-monero = { version = "2", default-features = false }
 //! ```
 //!
 //! or to enable `stream` one use:
 //!
 //! ```text
-//! base58-monero = { version = "1", features = ["stream"] }
+//! base58-monero = { version = "2", features = ["stream"] }
 //! ```
 //!
 //! ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Rust Monero Base58 Library
-// Written in 2019-2022 by
+// Written in 2019-2023 by
 //   Monero Rust Contributors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Prepare next major release: 2.0.0. Disable `check` feature by default and keep only `std` compatibility.