### PR TITLE
Update changelog

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,11 +9,11 @@ jobs:
   create_release:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: monero-rs/workflows/.github/workflows/create-release.yml@v2.0.2
+    uses: monero-rs/workflows/.github/workflows/create-release.yml@v3.0.3
 
   release_to_crates:
     name: Publish the new release to crates.io
     needs: create_release
-    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.2
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v3.0.3
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   draft-new-release:
     name: Draft a new release
-    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v2.0.2
+    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v3.0.3
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   release:
     name: Publish the new release to crates.io
-    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v2.0.2
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v3.0.3
     secrets:
       cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed MSRV to `1.71.0`.
+- Updated `thiserror` to 2.0.
+
 ## [2.0.0] - 2023-09-15
 
 ### Added


### PR DESCRIPTION
Preparing for 2.1.0 release

The release workflow needs to be triggered manually as described in RELEASING.md. It creates a PR similar to this one: https://github.com/monero-rs/monero-rpc-rs/pull/156. The crate will be published once the PR is merged, though that may require @h4sh3d's credentials

Supersedes https://github.com/monero-rs/base58-monero/pull/57